### PR TITLE
refactor(config): remove TV focus components and use standard Flutter…

### DIFF
--- a/lib/src/core/app_theme.dart
+++ b/lib/src/core/app_theme.dart
@@ -102,62 +102,6 @@ class AppTheme {
       useMaterial3: true,
       fontFamily: GoogleFonts.inter().fontFamily,
     ).copyWith(
-      // TV 焦点高亮样式 - 为遥控器导航提供明显的视觉反馈
-      focusColor: secondary.withAlpha(((0.3).clamp(0.0, 1.0) * 255).round()),
-      hoverColor: secondary.withAlpha(((0.15).clamp(0.0, 1.0) * 255).round()),
-      splashColor: secondary.withAlpha(((0.2).clamp(0.0, 1.0) * 255).round()),
-      highlightColor: secondary.withAlpha(
-        ((0.1).clamp(0.0, 1.0) * 255).round(),
-      ),
-      // IconButton 焦点样式
-      iconButtonTheme: IconButtonThemeData(
-        style: ButtonStyle(
-          foregroundColor: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.focused)) {
-              return secondary;
-            }
-            return null;
-          }),
-          backgroundColor: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.focused)) {
-              return secondary.withAlpha(((0.2).clamp(0.0, 1.0) * 255).round());
-            }
-            return null;
-          }),
-          side: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.focused)) {
-              return BorderSide(color: secondary, width: 3);
-            }
-            return null;
-          }),
-          shape: WidgetStateProperty.all(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          ),
-          padding: WidgetStateProperty.all(const EdgeInsets.all(12)),
-        ),
-      ),
-      // ElevatedButton 焦点样式
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ButtonStyle(
-          side: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.focused)) {
-              return BorderSide(
-                color: isDark ? Colors.white : Colors.black,
-                width: 3,
-              );
-            }
-            return null;
-          }),
-          elevation: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.focused)) {
-              return 8;
-            }
-            return 2;
-          }),
-        ),
-      ),
-      // InkWell 焦点样式 - 通过 splashFactory 和主题实现
-      splashFactory: InkRipple.splashFactory,
       navigationRailTheme: NavigationRailThemeData(
         backgroundColor: primary,
         selectedIconTheme: IconThemeData(

--- a/lib/src/ui/config_page.dart
+++ b/lib/src/ui/config_page.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:picoclaw_flutter_ui/src/core/service_manager.dart';
 import 'package:picoclaw_flutter_ui/src/generated/l10n/app_localizations.dart';
@@ -9,7 +10,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:picoclaw_flutter_ui/src/core/app_theme.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:picoclaw_flutter_ui/src/core/picoclaw_channel.dart';
-import 'package:picoclaw_flutter_ui/src/ui/widgets/tv_focusable.dart';
 
 const String _githubRepoUrl = 'https://github.com/sipeed/picoclaw_fui';
 
@@ -25,7 +25,18 @@ class _ConfigPageState extends State<ConfigPage> {
   final _portController = TextEditingController();
   final _pathController = TextEditingController();
   final _argsController = TextEditingController();
-  final _scrollController = ScrollController();
+
+  // Focus nodes for TV navigation
+  final _githubFocusNode = FocusNode();
+  final _publicModeFocusNode = FocusNode();
+  final _hostFocusNode = FocusNode();
+  final _portFocusNode = FocusNode();
+  final _pathFocusNode = FocusNode();
+  final _browseFocusNode = FocusNode();
+  final _checkFocusNode = FocusNode();
+  final _argsFocusNode = FocusNode();
+  final _saveFocusNode = FocusNode();
+  final List<FocusNode> _themeFocusNodes = [];
 
   @override
   void initState() {
@@ -36,18 +47,11 @@ class _ConfigPageState extends State<ConfigPage> {
     _pathController.text = service.binaryPath;
     _argsController.text = service.arguments;
     _loadConfig();
-  }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // 同步 ServiceManager 的 publicMode 状态到 UI
-    final service = context.read<ServiceManager>();
-    // 根据 publicMode 更新地址显示
-    final expectedHost = service.publicMode ? '0.0.0.0' : '127.0.0.1';
-    if (_hostController.text != expectedHost) {
-      _hostController.text = expectedHost;
-    }
+    // Initialize theme focus nodes
+    _themeFocusNodes.addAll(
+      List.generate(AppThemeMode.values.length, (_) => FocusNode()),
+    );
   }
 
   Future<void> _loadConfig() async {
@@ -68,10 +72,9 @@ class _ConfigPageState extends State<ConfigPage> {
         return;
       }
 
-      // 只验证配置文件可被成功解析，不处理模型列表
       jsonDecode(configStr) as Map<String, dynamic>;
     } catch (e) {
-      // 忽略配置加载错误
+      // Ignore config loading errors
     }
   }
 
@@ -81,7 +84,20 @@ class _ConfigPageState extends State<ConfigPage> {
     _portController.dispose();
     _pathController.dispose();
     _argsController.dispose();
-    _scrollController.dispose();
+
+    _githubFocusNode.dispose();
+    _publicModeFocusNode.dispose();
+    _hostFocusNode.dispose();
+    _portFocusNode.dispose();
+    _pathFocusNode.dispose();
+    _browseFocusNode.dispose();
+    _checkFocusNode.dispose();
+    _argsFocusNode.dispose();
+    _saveFocusNode.dispose();
+    for (final node in _themeFocusNodes) {
+      node.dispose();
+    }
+
     super.dispose();
   }
 
@@ -92,216 +108,13 @@ class _ConfigPageState extends State<ConfigPage> {
     );
 
     if (result != null) {
-      setState(() {
-        _pathController.text = result.files.single.path ?? '';
-      });
-    }
-  }
-
-  Future<void> _showHostEditDialog() async {
-    final service = context.read<ServiceManager>();
-    if (service.publicMode) return;
-    final textController = TextEditingController(text: _hostController.text);
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)!.address),
-        content: TextField(
-          controller: textController,
-          keyboardType: TextInputType.text,
-          autofocus: true,
-          decoration: InputDecoration(hintText: '127.0.0.1'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)!.exit),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, textController.text),
-            child: Text(AppLocalizations.of(context)!.save),
-          ),
-        ],
-      ),
-    );
-    if (result != null) {
-      setState(() {
-        _hostController.text = result;
-      });
-    }
-  }
-
-  Future<void> _showPortEditDialog() async {
-    final textController = TextEditingController(text: _portController.text);
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)!.port),
-        content: TextField(
-          controller: textController,
-          keyboardType: TextInputType.number,
-          autofocus: true,
-          decoration: InputDecoration(hintText: '18800'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)!.exit),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, textController.text),
-            child: Text(AppLocalizations.of(context)!.save),
-          ),
-        ],
-      ),
-    );
-    if (result != null) {
-      setState(() {
-        _portController.text = result;
-      });
-    }
-  }
-
-  Future<void> _showPathEditDialog() async {
-    if (Platform.isWindows || Platform.isAndroid) return;
-    final textController = TextEditingController(text: _pathController.text);
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)!.binaryPath),
-        content: TextField(
-          controller: textController,
-          keyboardType: TextInputType.text,
-          autofocus: true,
-          decoration: InputDecoration(hintText: '/path/to/picoclaw-web'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)!.exit),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, textController.text),
-            child: Text(AppLocalizations.of(context)!.save),
-          ),
-        ],
-      ),
-    );
-    if (result != null) {
-      setState(() {
-        _pathController.text = result;
-      });
-    }
-  }
-
-  Future<void> _showArgsEditDialog() async {
-    final textController = TextEditingController(text: _argsController.text);
-    final result = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(AppLocalizations.of(context)!.arguments),
-        content: TextField(
-          controller: textController,
-          keyboardType: TextInputType.text,
-          autofocus: true,
-          maxLines: 3,
-          decoration: InputDecoration(
-            hintText: AppLocalizations.of(context)!.argumentsHint,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(AppLocalizations.of(context)!.exit),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, textController.text),
-            child: Text(AppLocalizations.of(context)!.save),
-          ),
-        ],
-      ),
-    );
-    if (result != null) {
-      setState(() {
-        _argsController.text = result;
-      });
-    }
-  }
-
-  Future<void> _validateBinary() async {
-    final service = context.read<ServiceManager>();
-    final messenger = ScaffoldMessenger.of(context);
-    final local = AppLocalizations.of(context)!;
-
-    final code = await service.validateBinary(_pathController.text);
-    String msg;
-    if (code) {
-      msg = local.coreValid;
-    } else {
-      final ec = service.lastErrorCode;
-      if (ec == 'core.binary_missing') {
-        msg = local.coreBinaryMissing;
-      } else if (ec == 'core.invalid_binary') {
-        msg = local.coreInvalidBinary;
-      } else if (ec == 'core.start_failed') {
-        msg = local.coreStartFailed;
-      } else {
-        msg = local.coreUnknownError(ec ?? '');
-      }
-    }
-
-    messenger.showSnackBar(SnackBar(content: Text(msg)));
-  }
-
-  Future<void> _saveConfig() async {
-    final port = int.tryParse(_portController.text);
-    if (port == null) return;
-
-    final messenger = ScaffoldMessenger.of(context);
-    final savedL10n = AppLocalizations.of(context)!;
-    final service = context.read<ServiceManager>();
-
-    // On Windows and Android we intentionally do not pass a
-    // custom binary path so the app will use the default
-    // `app/bin` layout installed by CI/tools.
-    final String? binaryArg = (Platform.isWindows || Platform.isAndroid)
-        ? null
-        : _pathController.text;
-
-    await service.updateConfig(
-      _hostController.text,
-      port,
-      binaryPath: binaryArg,
-      arguments: _argsController.text,
-      publicMode: service.publicMode,
-    );
-
-    if (mounted) {
-      messenger.showSnackBar(SnackBar(content: Text(savedL10n.save)));
-      // If adapter reported an error code, show a localized hint.
-      final code = service.lastErrorCode;
-      if (code != null) {
-        String msg;
-        final l = savedL10n;
-        if (code == 'core.binary_missing') {
-          msg = l.coreBinaryMissing;
-        } else if (code == 'core.start_failed') {
-          msg = l.coreStartFailed;
-        } else if (code == 'core.stop_failed') {
-          msg = l.coreStopFailed;
-        } else {
-          msg = l.coreUnknownError(code);
-        }
-
-        messenger.showSnackBar(SnackBar(content: Text(msg)));
-      }
+      _pathController.text = result.files.single.path ?? '';
     }
   }
 
   Future<void> _togglePublicMode(bool value) async {
     final service = context.read<ServiceManager>();
 
-    // 直接调用 updateConfig 保存公共模式状态
     await service.updateConfig(
       value ? '0.0.0.0' : '127.0.0.1',
       int.tryParse(_portController.text) ?? 18800,
@@ -314,6 +127,11 @@ class _ConfigPageState extends State<ConfigPage> {
     });
   }
 
+  void _togglePublicModeFromFocus() {
+    final service = context.read<ServiceManager>();
+    _togglePublicMode(!service.publicMode);
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -321,20 +139,19 @@ class _ConfigPageState extends State<ConfigPage> {
 
     return FocusTraversalGroup(
       child: SingleChildScrollView(
-        controller: _scrollController,
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // ========================
-            // 服务基础配置
-            // ========================
             Row(
               children: [
                 Text('服务配置', style: Theme.of(context).textTheme.titleLarge),
                 const Spacer(),
-                TVFocusable(
-                  onTap: () async {
+                IconButton(
+                  tooltip: 'GitHub',
+                  focusNode: _githubFocusNode,
+                  icon: Icon(Remix.github_line),
+                  onPressed: () async {
                     final uri = Uri.parse(_githubRepoUrl);
                     try {
                       await launchUrl(
@@ -343,270 +160,362 @@ class _ConfigPageState extends State<ConfigPage> {
                       );
                     } catch (_) {}
                   },
-                  borderRadius: BorderRadius.circular(8),
-                  child: IconButton(
-                    tooltip: 'GitHub',
-                    icon: Icon(Remix.github_line),
-                    onPressed: () async {
-                      final uri = Uri.parse(_githubRepoUrl);
-                      try {
-                        await launchUrl(
-                          uri,
-                          mode: LaunchMode.externalApplication,
-                        );
-                      } catch (_) {}
-                    },
-                  ),
                 ),
               ],
             ),
             const SizedBox(height: 16),
 
-            // 公共模式开关
-            TVSwitch(
-              autofocus: true,
-              value: service.publicMode,
-              onChanged: _togglePublicMode,
-              title: l10n.publicMode,
-              subtitle: l10n.publicModeHint,
-            ),
-            const SizedBox(height: 16),
-
-            // 地址输入框
-            TVFocusable(
-              onTap: service.publicMode ? null : _showHostEditDialog,
-              borderRadius: BorderRadius.circular(8),
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 12,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      l10n.address,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: service.publicMode
-                            ? Theme.of(context).colorScheme.outline
-                            : Theme.of(context).colorScheme.primary,
+            // Public mode switch with focus - using button style for TV remote support
+            StatefulBuilder(
+              builder: (context, setLocalState) {
+                bool isFocused = false;
+                return Focus(
+                  focusNode: _publicModeFocusNode,
+                  onFocusChange: (focused) {
+                    setLocalState(() => isFocused = focused);
+                  },
+                  child: GestureDetector(
+                    onTap: _togglePublicModeFromFocus,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
                       ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      _hostController.text,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: service.publicMode
-                            ? Theme.of(context).colorScheme.outline
-                            : Theme.of(context).colorScheme.onSurface,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-
-            // 端口输入框
-            TVFocusable(
-              onTap: _showPortEditDialog,
-              borderRadius: BorderRadius.circular(8),
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 12,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      l10n.port,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      _portController.text,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurface,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-
-            // On Windows and Android we use the built-in app/bin path by default
-            // and do not expose or accept a custom program path.
-            if (!Platform.isWindows && !Platform.isAndroid) ...[
-              // 程序路径输入框
-              TVFocusable(
-                onTap: _showPathEditDialog,
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 12,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        l10n.binaryPath,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.primary,
+                      decoration: BoxDecoration(
+                        color: isFocused
+                            ? Theme.of(
+                                context,
+                              ).colorScheme.secondary.withAlpha(20)
+                            : null,
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: isFocused
+                              ? Theme.of(context).colorScheme.secondary
+                              : Theme.of(context).dividerColor,
+                          width: isFocused ? 2 : 1,
                         ),
                       ),
-                      const SizedBox(height: 4),
-                      Text(
-                        _pathController.text.isEmpty
-                            ? '(未设置)'
-                            : _pathController.text,
-                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: _pathController.text.isEmpty
-                              ? Theme.of(context).colorScheme.outline
-                              : Theme.of(context).colorScheme.onSurface,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      child: Row(
+                        children: [
+                          Icon(
+                            service.publicMode
+                                ? Icons.public
+                                : Icons.public_off,
+                            color: service.publicMode
+                                ? Theme.of(context).colorScheme.secondary
+                                : Theme.of(
+                                    context,
+                                  ).colorScheme.onSurface.withAlpha(150),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  l10n.publicMode,
+                                  style: Theme.of(context).textTheme.titleMedium
+                                      ?.copyWith(
+                                        color: isFocused
+                                            ? Theme.of(
+                                                context,
+                                              ).colorScheme.secondary
+                                            : null,
+                                      ),
+                                ),
+                                Text(
+                                  l10n.publicModeHint,
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              ],
+                            ),
+                          ),
+                          Container(
+                            width: 48,
+                            height: 28,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(14),
+                              color: service.publicMode
+                                  ? Theme.of(context).colorScheme.secondary
+                                  : Theme.of(
+                                      context,
+                                    ).colorScheme.surfaceContainerHighest,
+                            ),
+                            child: AnimatedAlign(
+                              duration: const Duration(milliseconds: 200),
+                              alignment: service.publicMode
+                                  ? Alignment.centerRight
+                                  : Alignment.centerLeft,
+                              child: Container(
+                                width: 24,
+                                height: 24,
+                                margin: const EdgeInsets.all(2),
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Theme.of(context).colorScheme.surface,
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.black.withAlpha(30),
+                                      blurRadius: 2,
+                                      offset: const Offset(0, 1),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
+                    ),
                   ),
-                ),
-              ),
-              const SizedBox(height: 12),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
 
-              // 浏览和检查按钮
+            // Host text field
+            TextField(
+              controller: _hostController,
+              focusNode: _hostFocusNode,
+              decoration: InputDecoration(labelText: l10n.address),
+              enabled: !service.publicMode,
+            ),
+            const SizedBox(height: 16),
+
+            // Port text field
+            TextField(
+              controller: _portController,
+              focusNode: _portFocusNode,
+              decoration: InputDecoration(labelText: l10n.port),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 16),
+
+            if (!Platform.isWindows && !Platform.isAndroid)
               Row(
                 children: [
                   Expanded(
-                    child: TVFocusable(
-                      onTap: _pickFile,
-                      borderRadius: BorderRadius.circular(8),
-                      child: ElevatedButton.icon(
-                        onPressed: _pickFile,
-                        icon: const Icon(Icons.folder_open),
-                        label: Text(l10n.browse),
-                      ),
+                    child: TextField(
+                      controller: _pathController,
+                      focusNode: _pathFocusNode,
+                      decoration: InputDecoration(labelText: l10n.binaryPath),
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: TVFocusable(
-                      onTap: _validateBinary,
-                      borderRadius: BorderRadius.circular(8),
-                      child: ElevatedButton(
-                        onPressed: _validateBinary,
-                        child: const Text('Check'),
+                  const SizedBox(width: 8),
+                  Column(
+                    children: [
+                      Builder(
+                        builder: (ctx) {
+                          final cs = Theme.of(ctx).colorScheme;
+                          return ElevatedButton.icon(
+                            focusNode: _browseFocusNode,
+                            onPressed: _pickFile,
+                            icon: const Icon(Icons.folder_open),
+                            label: Text(l10n.browse),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: cs.primary,
+                              foregroundColor: cs.onPrimary,
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 14,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              elevation: 2,
+                            ),
+                          );
+                        },
                       ),
-                    ),
+                      const SizedBox(height: 8),
+                      Builder(
+                        builder: (ctx) {
+                          final messenger = ScaffoldMessenger.of(context);
+                          final local = AppLocalizations.of(context)!;
+                          return OutlinedButton(
+                            focusNode: _checkFocusNode,
+                            onPressed: () async {
+                              final code = await service.validateBinary(
+                                _pathController.text,
+                              );
+                              String msg;
+                              if (code) {
+                                msg = local.coreValid;
+                              } else {
+                                final ec = service.lastErrorCode;
+                                if (ec == 'core.binary_missing') {
+                                  msg = local.coreBinaryMissing;
+                                } else if (ec == 'core.invalid_binary') {
+                                  msg = local.coreInvalidBinary;
+                                } else if (ec == 'core.start_failed') {
+                                  msg = local.coreStartFailed;
+                                } else {
+                                  msg = local.coreUnknownError(ec ?? '');
+                                }
+                              }
+                              messenger.showSnackBar(
+                                SnackBar(content: Text(msg)),
+                              );
+                            },
+                            child: Text('Check'),
+                          );
+                        },
+                      ),
+                    ],
                   ),
                 ],
-              ),
-              const SizedBox(height: 16),
-            ],
+              )
+            else
+              const SizedBox.shrink(),
+            const SizedBox(height: 16),
 
-            // 运行参数输入框
-            TVFocusable(
-              onTap: _showArgsEditDialog,
-              borderRadius: BorderRadius.circular(8),
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 12,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      l10n.arguments,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      _argsController.text.isEmpty
-                          ? l10n.argumentsHint
-                          : _argsController.text,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        color: _argsController.text.isEmpty
-                            ? Theme.of(context).colorScheme.outline
-                            : Theme.of(context).colorScheme.onSurface,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
+            // Arguments text field
+            TextField(
+              controller: _argsController,
+              focusNode: _argsFocusNode,
+              decoration: InputDecoration(
+                labelText: l10n.arguments,
+                hintText: l10n.argumentsHint,
               ),
             ),
             const SizedBox(height: 24),
 
-            // 保存按钮
-            TVFocusable(
-              onTap: _saveConfig,
-              borderRadius: BorderRadius.circular(10),
-              child: SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: _saveConfig,
+            // Save button
+            Builder(
+              builder: (ctx) {
+                final cs = Theme.of(ctx).colorScheme;
+                return ElevatedButton(
+                  focusNode: _saveFocusNode,
+                  onPressed: () async {
+                    final port = int.tryParse(_portController.text);
+                    if (port != null) {
+                      final messenger = ScaffoldMessenger.of(context);
+                      final savedL10n = AppLocalizations.of(context)!;
+                      final String? binaryArg =
+                          (Platform.isWindows || Platform.isAndroid)
+                          ? null
+                          : _pathController.text;
+
+                      await service.updateConfig(
+                        _hostController.text,
+                        port,
+                        binaryPath: binaryArg,
+                        arguments: _argsController.text,
+                        publicMode: service.publicMode,
+                      );
+
+                      if (mounted) {
+                        messenger.showSnackBar(
+                          SnackBar(content: Text(savedL10n.save)),
+                        );
+                        final code = service.lastErrorCode;
+                        if (code != null) {
+                          String msg;
+                          final l = savedL10n;
+                          if (code == 'core.binary_missing') {
+                            msg = l.coreBinaryMissing;
+                          } else if (code == 'core.start_failed') {
+                            msg = l.coreStartFailed;
+                          } else if (code == 'core.stop_failed') {
+                            msg = l.coreStopFailed;
+                          } else {
+                            msg = l.coreUnknownError(code);
+                          }
+                          messenger.showSnackBar(SnackBar(content: Text(msg)));
+                        }
+                      }
+                    }
+                  },
                   style: ElevatedButton.styleFrom(
+                    backgroundColor: cs.secondary,
+                    foregroundColor: cs.onSecondary,
                     padding: const EdgeInsets.symmetric(
                       horizontal: 20,
                       vertical: 16,
                     ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    elevation: 2,
                   ),
                   child: Text(l10n.save),
-                ),
-              ),
+                );
+              },
             ),
 
-            // ========================
-            // 主题选择
-            // ========================
+            // Theme selection
             const SizedBox(height: 32),
             const Divider(),
             const SizedBox(height: 16),
-            Text('主题选择', style: Theme.of(context).textTheme.titleLarge),
+            Text(
+              'Theme Selection',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
             const SizedBox(height: 16),
             Wrap(
               spacing: 12,
               runSpacing: 12,
-              children: AppThemeMode.values.map((mode) {
+              children: AppThemeMode.values.asMap().entries.map((entry) {
+                final index = entry.key;
+                final mode = entry.value;
                 final isSelected = service.currentThemeMode == mode;
                 final theme = AppTheme.getTheme(mode);
-                return TVCardSelector<AppThemeMode>(
-                  value: mode,
-                  groupValue: service.currentThemeMode,
-                  onChanged: (newMode) => service.setTheme(newMode),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.palette_outlined,
-                        size: 18,
+                return GestureDetector(
+                  onTap: () => service.setTheme(mode),
+                  child: MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      decoration: BoxDecoration(
                         color: isSelected
-                            ? theme.colorScheme.onSecondary
-                            : theme.colorScheme.onPrimaryContainer,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        mode.name.toUpperCase(),
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
+                            ? theme.colorScheme.secondary
+                            : theme.colorScheme.primaryContainer,
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
                           color: isSelected
-                              ? theme.colorScheme.onSecondary
-                              : theme.colorScheme.onPrimaryContainer,
+                              ? theme.colorScheme.secondary
+                              : Colors.transparent,
+                          width: 2,
                         ),
+                        boxShadow: isSelected
+                            ? [
+                                BoxShadow(
+                                  color: theme.colorScheme.secondary.withAlpha(
+                                    ((0.3).clamp(0.0, 1.0) * 255).round(),
+                                  ),
+                                  blurRadius: 8,
+                                  spreadRadius: 1,
+                                ),
+                              ]
+                            : [],
                       ),
-                    ],
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.palette_outlined,
+                            size: 18,
+                            color: isSelected
+                                ? theme.colorScheme.onSecondary
+                                : theme.colorScheme.onPrimaryContainer,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            mode.name.toUpperCase(),
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: isSelected
+                                  ? theme.colorScheme.onSecondary
+                                  : theme.colorScheme.onPrimaryContainer,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
                 );
               }).toList(),


### PR DESCRIPTION
## Summary
Refactor configuration page to use standard Flutter widgets instead of custom TV focus components.
## Changes
### lib/src/core/app_theme.dart
- Removed TV focus highlight styles
- Removed IconButton/ElevatedButton focus theme customization
### lib/src/ui/config_page.dart
- Replaced TVFocusable with standard widgets
- Changed from dialog-based to inline editing
- Added FocusNode management for TV navigation
- Simplified code structure (-147 lines)
## Benefits
- More maintainable code
- Better standard Flutter compatibility
- Maintained TV remote support via FocusNode