### PR TITLE
Fixed WebView navigation issues on Android platform where clicking me…

### DIFF
--- a/lib/src/ui/webview_page.dart
+++ b/lib/src/ui/webview_page.dart
@@ -113,6 +113,14 @@ class _WebViewPageState extends State<WebViewPage> {
                 setState(() => _isLoading = false);
               }
             },
+            onNavigationRequest: (NavigationRequest request) {
+              return NavigationDecision.navigate;
+            },
+            onUrlChange: (UrlChange change) {
+              if (mounted && _isLoading) {
+                setState(() => _isLoading = false);
+              }
+            },
           ),
         );
 
@@ -796,7 +804,7 @@ class _WebViewPageState extends State<WebViewPage> {
       );
     }
 
-    if (Platform.isAndroid || Platform.isIOS) {
+    if (Platform.isAndroid) {
       return Stack(
         key: _webviewStackKey,
         fit: StackFit.expand,
@@ -841,7 +849,55 @@ class _WebViewPageState extends State<WebViewPage> {
                   child: const Center(child: CircularProgressIndicator()),
                 )
               : const SizedBox.shrink(),
-          // Top action bar
+        ],
+      );
+    }
+
+    if (Platform.isIOS) {
+      return Stack(
+        key: _webviewStackKey,
+        fit: StackFit.expand,
+        children: [
+          Container(
+            color: Colors.white,
+            width: double.infinity,
+            height: double.infinity,
+            child: Listener(
+              onPointerDown: (event) {
+                if (event.kind == PointerDeviceKind.mouse &&
+                    event.buttons == kSecondaryMouseButton) {
+                  // Block right-click context menu
+                }
+              },
+              child: _mobileController == null
+                  ? Container(
+                      color: Colors.grey[200],
+                      width: double.infinity,
+                      height: double.infinity,
+                      child: const Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.web, size: 48, color: Colors.grey),
+                            SizedBox(height: 16),
+                            Text('Initializing WebView...'),
+                          ],
+                        ),
+                      ),
+                    )
+                  : SizedBox.expand(
+                      child: WebViewWidget(controller: _mobileController!),
+                    ),
+            ),
+          ),
+          _isLoading
+              ? Container(
+                  color: Colors.black.withAlpha((0.1 * 255).round()),
+                  width: double.infinity,
+                  height: double.infinity,
+                  child: const Center(child: CircularProgressIndicator()),
+                )
+              : const SizedBox.shrink(),
           buildWebViewActions(
             onBack: () async {
               if (_mobileController != null &&


### PR DESCRIPTION
## Summary
Fixed WebView navigation issues on Android platform where clicking menu items would cause the page to become unresponsive, and removed navigation action buttons for Android platform.
## Changes
### 1. Fix WebView Navigation Freezing Issue
**File:** `lib/src/ui/webview_page.dart`
**Problem:**
- When users clicked on menu items in the web page, the WebView would become unresponsive
- The page appeared frozen and could not be interacted with
- Refreshing the page would correctly navigate to the selected menu item
**Root Cause:**
- SPA (Single Page Application) routing using `history.pushState` or similar methods may not trigger `onPageStarted`/`onPageFinished` callbacks
- The `_isLoading` state was not being reset properly in certain navigation scenarios
- The loading overlay remained visible, blocking all user interactions
**Solution:**
- Added `onNavigationRequest` callback to explicitly allow all navigation requests
- Added `onUrlChange` callback to listen for URL changes and reset `_isLoading` state when SPA routing occurs
```dart
onNavigationRequest: (NavigationRequest request) {
  return NavigationDecision.navigate;
},
onUrlChange: (UrlChange change) {
  if (mounted && _isLoading) {
    setState(() => _isLoading = false);
  }
},
```
### 2. Hide Navigation Buttons on Android Platform
**File:** `lib/src/ui/webview_page.dart`
**Change:**
- Separated Android and iOS WebView implementations
- Removed the floating navigation action bar (back/forward/reload buttons) from Android platform
- Retained the navigation action bar for iOS and Windows platforms
**Rationale:**
- Android devices have native back navigation via system buttons or gestures
- Cleaner UI without redundant navigation controls on Android
- iOS and Windows platforms still benefit from the in-app navigation controls
