### PR TITLE
Fix mobile shell system bar styling

### DIFF
--- a/lib/src/ui/widgets/adaptive_action_bar.dart
+++ b/lib/src/ui/widgets/adaptive_action_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:picoclaw_flutter_ui/src/core/ui_constants.dart';
 
 /// AdaptiveActionBar
@@ -22,63 +23,100 @@ class AdaptiveActionBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
+        final theme = Theme.of(context);
         final isWide = constraints.maxWidth >= breakpoint;
         final orientation = MediaQuery.of(context).orientation;
         final useBottom = !isWide || orientation == Orientation.portrait;
+        final shellColor = theme.colorScheme.surface;
+        final overlayStyle = _systemUiOverlayStyleFor(shellColor);
 
         if (useBottom) {
-          return SafeArea(
-            child: Column(
-              children: [
-                Expanded(child: content),
-                Material(
-                  elevation: 8,
-                  color: Theme.of(context).colorScheme.surface,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      vertical: 8,
-                      horizontal: 12,
+          return AnnotatedRegion<SystemUiOverlayStyle>(
+            value: overlayStyle,
+            child: ColoredBox(
+              color: shellColor,
+              child: SafeArea(
+                child: Column(
+                  children: [
+                    Expanded(child: content),
+                    Material(
+                      elevation: 0,
+                      color: shellColor,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 8,
+                          horizontal: 12,
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: actions.map((a) => _wrapAction(a)).toList(),
+                        ),
+                      ),
                     ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: actions.map((a) => _wrapAction(a)).toList(),
-                    ),
-                  ),
+                  ],
                 ),
-              ],
+              ),
             ),
           );
         } else {
-          return SafeArea(
-            child: Row(
-              children: [
-                Expanded(child: content),
-                Container(
-                  width: kSideBarWidth,
-                  padding: const EdgeInsets.symmetric(vertical: 12),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).scaffoldBackgroundColor,
-                    boxShadow: [
-                      BoxShadow(color: Colors.black12, blurRadius: 6),
-                    ],
-                  ),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: actions
-                        .map(
-                          (a) => Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 8),
-                            child: _wrapAction(a),
-                          ),
-                        )
-                        .toList(),
-                  ),
+          return AnnotatedRegion<SystemUiOverlayStyle>(
+            value: overlayStyle,
+            child: ColoredBox(
+              color: shellColor,
+              child: SafeArea(
+                child: Row(
+                  children: [
+                    Expanded(child: content),
+                    Container(
+                      width: kSideBarWidth,
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      decoration: BoxDecoration(
+                        color: theme.scaffoldBackgroundColor,
+                        boxShadow: [
+                          BoxShadow(color: Colors.black12, blurRadius: 6),
+                        ],
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: actions
+                            .map(
+                              (a) => Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 8,
+                                ),
+                                child: _wrapAction(a),
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           );
         }
       },
+    );
+  }
+
+  SystemUiOverlayStyle _systemUiOverlayStyleFor(Color backgroundColor) {
+    final backgroundBrightness = ThemeData.estimateBrightnessForColor(
+      backgroundColor,
+    );
+    final useDarkIcons = backgroundBrightness == Brightness.light;
+
+    return SystemUiOverlayStyle(
+      statusBarColor: backgroundColor,
+      systemNavigationBarColor: backgroundColor,
+      systemNavigationBarDividerColor: backgroundColor,
+      statusBarIconBrightness: useDarkIcons
+          ? Brightness.dark
+          : Brightness.light,
+      systemNavigationBarIconBrightness: useDarkIcons
+          ? Brightness.dark
+          : Brightness.light,
+      statusBarBrightness: useDarkIcons ? Brightness.light : Brightness.dark,
     );
   }
 


### PR DESCRIPTION
## Summary
- align Android system bars with the content surface on mobile layouts
- remove the bottom bar shadow while keeping the desktop sidebar styling intact

| before | after |
| --- | --- |
|![67c378a82dca4c8a53eb123489a4145d](https://github.com/user-attachments/assets/d8a43b94-f09b-4771-a8ee-05d09d2dca47)|![045e2c0d13735aa1050cc32a2519a03d](https://github.com/user-attachments/assets/dd5b159d-2ada-4f74-9cbf-f497ed601703)|