### PR TITLE
Fix #2367: use localized string for settings page title

### DIFF
--- a/lib/src/ui/config_page.dart
+++ b/lib/src/ui/config_page.dart
@@ -184,7 +184,7 @@ class _ConfigPageState extends State<ConfigPage> {
           children: [
             Row(
               children: [
-                Text('服务配置', style: Theme.of(context).textTheme.titleLarge),
+                Text(l10n.settings, style: Theme.of(context).textTheme.titleLarge),
                 const Spacer(),
                 IconButton(
                   tooltip: 'GitHub',


### PR DESCRIPTION
## Summary

Fixes #2367

## Changes

The settings page title was hardcoded as Chinese '服务配置' instead of using the localized `l10n.settings` string.

Changed from:
```dart
Text('服务配置', style: Theme.of(context).textTheme.titleLarge),
```

To:
```dart
Text(l10n.settings, style: Theme.of(context).textTheme.titleLarge),
```

This ensures the settings page title properly respects the user's language selection.

## Testing

- Code change only - verifies that the localized string is used instead of hardcoded Chinese