### PR TITLE
feat: add settings about dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ migrate_working_dir/
 *.iws
 .idea/
 
+.agents
+.codex
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
@@ -51,4 +53,3 @@ app/bin/
 # User-specific configuration files
 .security.yml
 config.json*
-

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -96,5 +96,12 @@
   "discard": "تجاهل",
   "saved": "تم الحفظ",
   "language": "اللغة",
-  "selectLanguage": "اختر اللغة"
+  "selectLanguage": "اختر اللغة",
+  "about": "حول",
+  "aboutTitle": "حول PicoClaw Flutter UI",
+  "aboutDescription": "عميل Flutter متعدد المنصات لإدارة خدمة PicoClaw.",
+  "picoclawOfficial": "موقع PicoClaw الرسمي",
+  "sipeedOfficial": "موقع Sipeed الرسمي",
+  "openLinkFailed": "تعذر فتح الرابط الرسمي.",
+  "close": "إغلاق"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -96,5 +96,12 @@
   "discard": "Verwerfen",
   "saved": "Gespeichert",
   "language": "Sprache",
-  "selectLanguage": "Sprache auswählen"
+  "selectLanguage": "Sprache auswählen",
+  "about": "Über",
+  "aboutTitle": "Über PicoClaw Flutter UI",
+  "aboutDescription": "Eine plattformübergreifende Flutter-Oberfläche zur Verwaltung des PicoClaw-Dienstes.",
+  "picoclawOfficial": "Offizielle PicoClaw-Website",
+  "sipeedOfficial": "Offizielle Sipeed-Website",
+  "openLinkFailed": "Der offizielle Link konnte nicht geöffnet werden.",
+  "close": "Schließen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -104,5 +104,12 @@
   "discard": "Discard",
   "saved": "Saved",
   "language": "Language",
-  "selectLanguage": "Select Language"
+  "selectLanguage": "Select Language",
+  "about": "About",
+  "aboutTitle": "About PicoClaw Flutter UI",
+  "aboutDescription": "A cross-platform Flutter client for managing the PicoClaw service.",
+  "picoclawOfficial": "PicoClaw Official",
+  "sipeedOfficial": "Sipeed Official",
+  "openLinkFailed": "Couldn't open the official link.",
+  "close": "Close"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -96,5 +96,12 @@
   "discard": "Descartar",
   "saved": "Guardado",
   "language": "Idioma",
-  "selectLanguage": "Seleccionar idioma"
+  "selectLanguage": "Seleccionar idioma",
+  "about": "Acerca de",
+  "aboutTitle": "Acerca de PicoClaw Flutter UI",
+  "aboutDescription": "Un cliente Flutter multiplataforma para gestionar el servicio PicoClaw.",
+  "picoclawOfficial": "Sitio oficial de PicoClaw",
+  "sipeedOfficial": "Sitio oficial de Sipeed",
+  "openLinkFailed": "No se pudo abrir el enlace oficial.",
+  "close": "Cerrar"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -96,5 +96,12 @@
   "discard": "Abandonner",
   "saved": "Enregistré",
   "language": "Langue",
-  "selectLanguage": "Sélectionner la langue"
+  "selectLanguage": "Sélectionner la langue",
+  "about": "À propos",
+  "aboutTitle": "À propos de PicoClaw Flutter UI",
+  "aboutDescription": "Un client Flutter multiplateforme pour gérer le service PicoClaw.",
+  "picoclawOfficial": "Site officiel de PicoClaw",
+  "sipeedOfficial": "Site officiel de Sipeed",
+  "openLinkFailed": "Impossible d'ouvrir le lien officiel.",
+  "close": "Fermer"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -96,5 +96,12 @@
   "discard": "छोड़ें",
   "saved": "सहेजे गए",
   "language": "भाषा",
-  "selectLanguage": "भाषा चुनें"
+  "selectLanguage": "भाषा चुनें",
+  "about": "परिचय",
+  "aboutTitle": "PicoClaw Flutter UI के बारे में",
+  "aboutDescription": "PicoClaw सेवा को प्रबंधित करने के लिए एक क्रॉस-प्लेटफ़ॉर्म Flutter क्लाइंट।",
+  "picoclawOfficial": "PicoClaw आधिकारिक साइट",
+  "sipeedOfficial": "Sipeed आधिकारिक साइट",
+  "openLinkFailed": "आधिकारिक लिंक नहीं खुल सका।",
+  "close": "बंद करें"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -96,5 +96,12 @@
   "discard": "Buang",
   "saved": "Disimpan",
   "language": "Bahasa",
-  "selectLanguage": "Pilih bahasa"
+  "selectLanguage": "Pilih bahasa",
+  "about": "Tentang",
+  "aboutTitle": "Tentang PicoClaw Flutter UI",
+  "aboutDescription": "Klien Flutter lintas platform untuk mengelola layanan PicoClaw.",
+  "picoclawOfficial": "Situs Resmi PicoClaw",
+  "sipeedOfficial": "Situs Resmi Sipeed",
+  "openLinkFailed": "Gagal membuka tautan resmi.",
+  "close": "Tutup"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -96,5 +96,12 @@
   "discard": "破棄",
   "saved": "保存しました",
   "language": "言語",
-  "selectLanguage": "言語を選択"
+  "selectLanguage": "言語を選択",
+  "about": "概要",
+  "aboutTitle": "PicoClaw Flutter UI について",
+  "aboutDescription": "PicoClaw サービスを管理するためのクロスプラットフォーム Flutter クライアントです。",
+  "picoclawOfficial": "PicoClaw 公式サイト",
+  "sipeedOfficial": "Sipeed 公式サイト",
+  "openLinkFailed": "公式リンクを開けませんでした。",
+  "close": "閉じる"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -96,5 +96,12 @@
   "discard": "취소",
   "saved": "저장됨",
   "language": "언어",
-  "selectLanguage": "언어 선택"
+  "selectLanguage": "언어 선택",
+  "about": "정보",
+  "aboutTitle": "PicoClaw Flutter UI 정보",
+  "aboutDescription": "PicoClaw 서비스를 관리하기 위한 크로스 플랫폼 Flutter 클라이언트입니다.",
+  "picoclawOfficial": "PicoClaw 공식 사이트",
+  "sipeedOfficial": "Sipeed 공식 사이트",
+  "openLinkFailed": "공식 링크를 열 수 없습니다.",
+  "close": "닫기"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -96,5 +96,12 @@
   "discard": "Descartar",
   "saved": "Guardado",
   "language": "Idioma",
-  "selectLanguage": "Selecionar idioma"
+  "selectLanguage": "Selecionar idioma",
+  "about": "Sobre",
+  "aboutTitle": "Sobre o PicoClaw Flutter UI",
+  "aboutDescription": "Um cliente Flutter multiplataforma para gerir o serviço PicoClaw.",
+  "picoclawOfficial": "Site oficial do PicoClaw",
+  "sipeedOfficial": "Site oficial da Sipeed",
+  "openLinkFailed": "Não foi possível abrir o link oficial.",
+  "close": "Fechar"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -96,5 +96,12 @@
   "discard": "Отменить",
   "saved": "Сохранено",
   "language": "Язык",
-  "selectLanguage": "Выбрать язык"
+  "selectLanguage": "Выбрать язык",
+  "about": "О приложении",
+  "aboutTitle": "О PicoClaw Flutter UI",
+  "aboutDescription": "Кроссплатформенный Flutter-клиент для управления сервисом PicoClaw.",
+  "picoclawOfficial": "Официальный сайт PicoClaw",
+  "sipeedOfficial": "Официальный сайт Sipeed",
+  "openLinkFailed": "Не удалось открыть официальную ссылку.",
+  "close": "Закрыть"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -101,5 +101,12 @@
   "discard": "放弃",
   "saved": "已保存",
   "language": "语言",
-  "selectLanguage": "选择语言"
+  "selectLanguage": "选择语言",
+  "about": "关于",
+  "aboutTitle": "关于 PicoClaw Flutter UI",
+  "aboutDescription": "PicoClaw Flutter UI 是一个用于管理 PicoClaw 服务的跨平台 Flutter 客户端。",
+  "picoclawOfficial": "PicoClaw 官网",
+  "sipeedOfficial": "Sipeed 官网",
+  "openLinkFailed": "无法打开官方链接。",
+  "close": "关闭"
 }

--- a/lib/src/generated/l10n/app_localizations.dart
+++ b/lib/src/generated/l10n/app_localizations.dart
@@ -585,6 +585,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Select Language'**
   String get selectLanguage;
+
+  /// No description provided for @about.
+  ///
+  /// In en, this message translates to:
+  /// **'About'**
+  String get about;
+
+  /// No description provided for @aboutTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'About PicoClaw Flutter UI'**
+  String get aboutTitle;
+
+  /// No description provided for @aboutDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'A cross-platform Flutter client for managing the PicoClaw service.'**
+  String get aboutDescription;
+
+  /// No description provided for @picoclawOfficial.
+  ///
+  /// In en, this message translates to:
+  /// **'PicoClaw Official'**
+  String get picoclawOfficial;
+
+  /// No description provided for @sipeedOfficial.
+  ///
+  /// In en, this message translates to:
+  /// **'Sipeed Official'**
+  String get sipeedOfficial;
+
+  /// No description provided for @openLinkFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t open the official link.'**
+  String get openLinkFailed;
+
+  /// No description provided for @close.
+  ///
+  /// In en, this message translates to:
+  /// **'Close'**
+  String get close;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/src/generated/l10n/app_localizations_ar.dart
+++ b/lib/src/generated/l10n/app_localizations_ar.dart
@@ -262,4 +262,26 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get selectLanguage => 'اختر اللغة';
+
+  @override
+  String get about => 'حول';
+
+  @override
+  String get aboutTitle => 'حول PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'عميل Flutter متعدد المنصات لإدارة خدمة PicoClaw.';
+
+  @override
+  String get picoclawOfficial => 'موقع PicoClaw الرسمي';
+
+  @override
+  String get sipeedOfficial => 'موقع Sipeed الرسمي';
+
+  @override
+  String get openLinkFailed => 'تعذر فتح الرابط الرسمي.';
+
+  @override
+  String get close => 'إغلاق';
 }

--- a/lib/src/generated/l10n/app_localizations_de.dart
+++ b/lib/src/generated/l10n/app_localizations_de.dart
@@ -268,4 +268,27 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Sprache auswählen';
+
+  @override
+  String get about => 'Über';
+
+  @override
+  String get aboutTitle => 'Über PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'Eine plattformübergreifende Flutter-Oberfläche zur Verwaltung des PicoClaw-Dienstes.';
+
+  @override
+  String get picoclawOfficial => 'Offizielle PicoClaw-Website';
+
+  @override
+  String get sipeedOfficial => 'Offizielle Sipeed-Website';
+
+  @override
+  String get openLinkFailed =>
+      'Der offizielle Link konnte nicht geöffnet werden.';
+
+  @override
+  String get close => 'Schließen';
 }

--- a/lib/src/generated/l10n/app_localizations_en.dart
+++ b/lib/src/generated/l10n/app_localizations_en.dart
@@ -264,4 +264,26 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Select Language';
+
+  @override
+  String get about => 'About';
+
+  @override
+  String get aboutTitle => 'About PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'A cross-platform Flutter client for managing the PicoClaw service.';
+
+  @override
+  String get picoclawOfficial => 'PicoClaw Official';
+
+  @override
+  String get sipeedOfficial => 'Sipeed Official';
+
+  @override
+  String get openLinkFailed => 'Couldn\'t open the official link.';
+
+  @override
+  String get close => 'Close';
 }

--- a/lib/src/generated/l10n/app_localizations_es.dart
+++ b/lib/src/generated/l10n/app_localizations_es.dart
@@ -267,4 +267,26 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Seleccionar idioma';
+
+  @override
+  String get about => 'Acerca de';
+
+  @override
+  String get aboutTitle => 'Acerca de PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'Un cliente Flutter multiplataforma para gestionar el servicio PicoClaw.';
+
+  @override
+  String get picoclawOfficial => 'Sitio oficial de PicoClaw';
+
+  @override
+  String get sipeedOfficial => 'Sitio oficial de Sipeed';
+
+  @override
+  String get openLinkFailed => 'No se pudo abrir el enlace oficial.';
+
+  @override
+  String get close => 'Cerrar';
 }

--- a/lib/src/generated/l10n/app_localizations_fr.dart
+++ b/lib/src/generated/l10n/app_localizations_fr.dart
@@ -269,4 +269,26 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Sélectionner la langue';
+
+  @override
+  String get about => 'À propos';
+
+  @override
+  String get aboutTitle => 'À propos de PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'Un client Flutter multiplateforme pour gérer le service PicoClaw.';
+
+  @override
+  String get picoclawOfficial => 'Site officiel de PicoClaw';
+
+  @override
+  String get sipeedOfficial => 'Site officiel de Sipeed';
+
+  @override
+  String get openLinkFailed => 'Impossible d\'ouvrir le lien officiel.';
+
+  @override
+  String get close => 'Fermer';
 }

--- a/lib/src/generated/l10n/app_localizations_hi.dart
+++ b/lib/src/generated/l10n/app_localizations_hi.dart
@@ -264,4 +264,26 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get selectLanguage => 'भाषा चुनें';
+
+  @override
+  String get about => 'परिचय';
+
+  @override
+  String get aboutTitle => 'PicoClaw Flutter UI के बारे में';
+
+  @override
+  String get aboutDescription =>
+      'PicoClaw सेवा को प्रबंधित करने के लिए एक क्रॉस-प्लेटफ़ॉर्म Flutter क्लाइंट।';
+
+  @override
+  String get picoclawOfficial => 'PicoClaw आधिकारिक साइट';
+
+  @override
+  String get sipeedOfficial => 'Sipeed आधिकारिक साइट';
+
+  @override
+  String get openLinkFailed => 'आधिकारिक लिंक नहीं खुल सका।';
+
+  @override
+  String get close => 'बंद करें';
 }

--- a/lib/src/generated/l10n/app_localizations_id.dart
+++ b/lib/src/generated/l10n/app_localizations_id.dart
@@ -266,4 +266,26 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Pilih bahasa';
+
+  @override
+  String get about => 'Tentang';
+
+  @override
+  String get aboutTitle => 'Tentang PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'Klien Flutter lintas platform untuk mengelola layanan PicoClaw.';
+
+  @override
+  String get picoclawOfficial => 'Situs Resmi PicoClaw';
+
+  @override
+  String get sipeedOfficial => 'Situs Resmi Sipeed';
+
+  @override
+  String get openLinkFailed => 'Gagal membuka tautan resmi.';
+
+  @override
+  String get close => 'Tutup';
 }

--- a/lib/src/generated/l10n/app_localizations_ja.dart
+++ b/lib/src/generated/l10n/app_localizations_ja.dart
@@ -257,4 +257,26 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get selectLanguage => '言語を選択';
+
+  @override
+  String get about => '概要';
+
+  @override
+  String get aboutTitle => 'PicoClaw Flutter UI について';
+
+  @override
+  String get aboutDescription =>
+      'PicoClaw サービスを管理するためのクロスプラットフォーム Flutter クライアントです。';
+
+  @override
+  String get picoclawOfficial => 'PicoClaw 公式サイト';
+
+  @override
+  String get sipeedOfficial => 'Sipeed 公式サイト';
+
+  @override
+  String get openLinkFailed => '公式リンクを開けませんでした。';
+
+  @override
+  String get close => '閉じる';
 }

--- a/lib/src/generated/l10n/app_localizations_ko.dart
+++ b/lib/src/generated/l10n/app_localizations_ko.dart
@@ -258,4 +258,26 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get selectLanguage => '언어 선택';
+
+  @override
+  String get about => '정보';
+
+  @override
+  String get aboutTitle => 'PicoClaw Flutter UI 정보';
+
+  @override
+  String get aboutDescription =>
+      'PicoClaw 서비스를 관리하기 위한 크로스 플랫폼 Flutter 클라이언트입니다.';
+
+  @override
+  String get picoclawOfficial => 'PicoClaw 공식 사이트';
+
+  @override
+  String get sipeedOfficial => 'Sipeed 공식 사이트';
+
+  @override
+  String get openLinkFailed => '공식 링크를 열 수 없습니다.';
+
+  @override
+  String get close => '닫기';
 }

--- a/lib/src/generated/l10n/app_localizations_pt.dart
+++ b/lib/src/generated/l10n/app_localizations_pt.dart
@@ -269,4 +269,26 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Selecionar idioma';
+
+  @override
+  String get about => 'Sobre';
+
+  @override
+  String get aboutTitle => 'Sobre o PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'Um cliente Flutter multiplataforma para gerir o serviço PicoClaw.';
+
+  @override
+  String get picoclawOfficial => 'Site oficial do PicoClaw';
+
+  @override
+  String get sipeedOfficial => 'Site oficial da Sipeed';
+
+  @override
+  String get openLinkFailed => 'Não foi possível abrir o link oficial.';
+
+  @override
+  String get close => 'Fechar';
 }

--- a/lib/src/generated/l10n/app_localizations_ru.dart
+++ b/lib/src/generated/l10n/app_localizations_ru.dart
@@ -267,4 +267,26 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get selectLanguage => 'Выбрать язык';
+
+  @override
+  String get about => 'О приложении';
+
+  @override
+  String get aboutTitle => 'О PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'Кроссплатформенный Flutter-клиент для управления сервисом PicoClaw.';
+
+  @override
+  String get picoclawOfficial => 'Официальный сайт PicoClaw';
+
+  @override
+  String get sipeedOfficial => 'Официальный сайт Sipeed';
+
+  @override
+  String get openLinkFailed => 'Не удалось открыть официальную ссылку.';
+
+  @override
+  String get close => 'Закрыть';
 }

--- a/lib/src/generated/l10n/app_localizations_zh.dart
+++ b/lib/src/generated/l10n/app_localizations_zh.dart
@@ -255,4 +255,26 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get selectLanguage => '选择语言';
+
+  @override
+  String get about => '关于';
+
+  @override
+  String get aboutTitle => '关于 PicoClaw Flutter UI';
+
+  @override
+  String get aboutDescription =>
+      'PicoClaw Flutter UI 是一个用于管理 PicoClaw 服务的跨平台 Flutter 客户端。';
+
+  @override
+  String get picoclawOfficial => 'PicoClaw 官网';
+
+  @override
+  String get sipeedOfficial => 'Sipeed 官网';
+
+  @override
+  String get openLinkFailed => '无法打开官方链接。';
+
+  @override
+  String get close => '关闭';
 }

--- a/lib/src/ui/config_page.dart
+++ b/lib/src/ui/config_page.dart
@@ -10,13 +10,29 @@ import 'package:picoclaw_flutter_ui/src/core/app_theme.dart';
 import 'package:remixicon/remixicon.dart';
 
 const String _githubRepoUrl = 'https://github.com/sipeed/picoclaw_fui';
+const String _picoclawOfficialUrl = 'https://picoclaw.io';
+const String _sipeedOfficialUrl = 'https://sipeed.com';
+const String _aboutProjectName = 'PicoClaw Flutter UI';
+
+typedef ExternalUrlLauncher = Future<bool> Function(Uri uri);
+
+Future<bool> _defaultExternalUrlLauncher(Uri uri) {
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
 
 class ConfigPage extends StatefulWidget {
   final ValueChanged<bool>? onDirtyChanged;
+
   /// Called once with the save function, so MainShell can call it later.
   final void Function(Future<void> Function()? saveFn)? onSaveFnReady;
+  final ExternalUrlLauncher externalUrlLauncher;
 
-  const ConfigPage({super.key, this.onDirtyChanged, this.onSaveFnReady});
+  const ConfigPage({
+    super.key,
+    this.onDirtyChanged,
+    this.onSaveFnReady,
+    this.externalUrlLauncher = _defaultExternalUrlLauncher,
+  });
 
   @override
   State<ConfigPage> createState() => ConfigPageState();
@@ -31,6 +47,7 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
   final _argsController = TextEditingController();
 
   // Focus nodes for TV navigation
+  final _aboutFocusNode = FocusNode();
   final _githubFocusNode = FocusNode();
   final _publicModeFocusNode = FocusNode();
   final _hostFocusNode = FocusNode();
@@ -143,6 +160,7 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
     _pathController.dispose();
     _argsController.dispose();
 
+    _aboutFocusNode.dispose();
     _githubFocusNode.dispose();
     _publicModeFocusNode.dispose();
     _hostFocusNode.dispose();
@@ -242,6 +260,72 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
     _togglePublicMode(!service.publicMode);
   }
 
+  Future<bool> _launchExternalUrl(Uri uri) async {
+    try {
+      final launched = await widget.externalUrlLauncher(uri);
+      if (launched) return true;
+    } catch (_) {}
+
+    if (!mounted) return false;
+    final l10n = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(l10n.openLinkFailed)));
+    return false;
+  }
+
+  Future<void> _showAboutDialog() async {
+    final l10n = AppLocalizations.of(context)!;
+
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.aboutTitle),
+        content: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 420),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                _aboutProjectName,
+                style: Theme.of(
+                  ctx,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 12),
+              Text(l10n.aboutDescription),
+              const SizedBox(height: 16),
+              TextButton.icon(
+                autofocus: true,
+                onPressed: () =>
+                    _launchExternalUrl(Uri.parse(_picoclawOfficialUrl)),
+                icon: const Icon(Icons.open_in_new),
+                label: Text(l10n.picoclawOfficial),
+              ),
+              TextButton.icon(
+                onPressed: () =>
+                    _launchExternalUrl(Uri.parse(_sipeedOfficialUrl)),
+                icon: const Icon(Icons.open_in_new),
+                label: Text(l10n.sipeedOfficial),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l10n.close),
+          ),
+        ],
+      ),
+    );
+
+    if (mounted) {
+      _aboutFocusNode.requestFocus();
+    }
+  }
+
   Future<void> _toggleFirebase(BuildContext context) async {
     final service = context.read<ServiceManager>();
     final newValue = !_firebaseAllowed;
@@ -292,7 +376,11 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
             return AlertDialog(
               title: Text(
                 AppLocalizations.of(ctx)!.unsavedChanges,
-                style: TextStyle(color: colorScheme.secondary, fontSize: 20, fontWeight: FontWeight.bold),
+                style: TextStyle(
+                  color: colorScheme.secondary,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
               content: Text(
                 AppLocalizations.of(ctx)!.unsavedChangesHint,
@@ -301,11 +389,17 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
               actions: [
                 TextButton(
                   onPressed: () => Navigator.of(ctx).pop(false),
-                  child: Text(AppLocalizations.of(ctx)!.cancel, style: btnStyle),
+                  child: Text(
+                    AppLocalizations.of(ctx)!.cancel,
+                    style: btnStyle,
+                  ),
                 ),
                 TextButton(
                   onPressed: () => Navigator.of(ctx).pop(true),
-                  child: Text(AppLocalizations.of(ctx)!.discard, style: btnStyle),
+                  child: Text(
+                    AppLocalizations.of(ctx)!.discard,
+                    style: btnStyle,
+                  ),
                 ),
               ],
             );
@@ -328,18 +422,51 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   const Spacer(),
+                  Tooltip(
+                    message: l10n.about,
+                    child: FocusableButton(
+                      focusNode: _aboutFocusNode,
+                      onPressed: () {
+                        _showAboutDialog();
+                      },
+                      prevFocusNode: _aboutFocusNode,
+                      nextFocusNode: _publicModeFocusNode,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Theme.of(context).colorScheme.surface,
+                        foregroundColor: Theme.of(
+                          context,
+                        ).colorScheme.onSurface,
+                        elevation: 0,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          side: BorderSide(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.outline.withAlpha(60),
+                          ),
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.info_outline, size: 18),
+                          const SizedBox(width: 6),
+                          Text(l10n.about),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
                   IconButton(
                     tooltip: 'GitHub',
                     focusNode: _githubFocusNode,
-                    icon: Icon(Remix.github_line),
+                    icon: const Icon(Remix.github_line),
                     onPressed: () async {
-                      final uri = Uri.parse(_githubRepoUrl);
-                      try {
-                        await launchUrl(
-                          uri,
-                          mode: LaunchMode.externalApplication,
-                        );
-                      } catch (_) {}
+                      await _launchExternalUrl(Uri.parse(_githubRepoUrl));
                     },
                   ),
                 ],
@@ -353,7 +480,7 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
                   isPublicMode: isPublicMode,
                   onToggle: _togglePublicModeFromFocus,
                   onArrowDown: () => _hostFocusNode.requestFocus(),
-                  onArrowUp: () => _githubFocusNode.requestFocus(),
+                  onArrowUp: () => _aboutFocusNode.requestFocus(),
                 ),
               ),
               const SizedBox(height: 16),
@@ -661,11 +788,16 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Theme.of(context).colorScheme.surface,
                       foregroundColor: Theme.of(context).colorScheme.onSurface,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8),
                         side: BorderSide(
-                          color: Theme.of(context).colorScheme.outline.withAlpha(60),
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.outline.withAlpha(60),
                         ),
                       ),
                     ),
@@ -674,10 +806,14 @@ class ConfigPageState extends State<ConfigPage> with WidgetsBindingObserver {
                       tooltip: l10n.selectLanguage,
                       onSelected: (locale) => service.setLocale(locale),
                       itemBuilder: (ctx) => AppLocalizations.supportedLocales
-                          .map((locale) => PopupMenuItem(
-                                value: locale,
-                                child: Text(_getLanguageName(locale.languageCode)),
-                              ))
+                          .map(
+                            (locale) => PopupMenuItem(
+                              value: locale,
+                              child: Text(
+                                _getLanguageName(locale.languageCode),
+                              ),
+                            ),
+                          )
                           .toList(),
                       child: Row(
                         mainAxisSize: MainAxisSize.min,

--- a/test/widgets/config_page_about_dialog_test.dart
+++ b/test/widgets/config_page_about_dialog_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:picoclaw_flutter_ui/src/core/service_manager.dart';
+import 'package:picoclaw_flutter_ui/src/generated/l10n/app_localizations.dart';
+import 'package:picoclaw_flutter_ui/src/ui/config_page.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<void> pumpConfigPage(
+    WidgetTester tester, {
+    ExternalUrlLauncher? launcher,
+  }) async {
+    final service = ServiceManager();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ServiceManager>.value(
+        value: service,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ConfigPage(
+              externalUrlLauncher: launcher ?? ((_) async => true),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('opens and closes the about dialog from settings', (
+    WidgetTester tester,
+  ) async {
+    await pumpConfigPage(tester);
+
+    expect(find.text('About'), findsOneWidget);
+
+    await tester.tap(find.text('About'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('About PicoClaw Flutter UI'), findsOneWidget);
+    expect(
+      find.text(
+        'A cross-platform Flutter client for managing the PicoClaw service.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('About PicoClaw Flutter UI'), findsNothing);
+  });
+
+  testWidgets('shows project info and official links in the about dialog', (
+    WidgetTester tester,
+  ) async {
+    await pumpConfigPage(tester);
+
+    await tester.tap(find.text('About'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('PicoClaw Flutter UI'), findsOneWidget);
+    expect(find.text('PicoClaw Official'), findsOneWidget);
+    expect(find.text('Sipeed Official'), findsOneWidget);
+  });
+
+  testWidgets('launches both official links from the about dialog', (
+    WidgetTester tester,
+  ) async {
+    final launchedUris = <Uri>[];
+
+    await pumpConfigPage(
+      tester,
+      launcher: (uri) async {
+        launchedUris.add(uri);
+        return true;
+      },
+    );
+
+    await tester.tap(find.text('About'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('PicoClaw Official'));
+    await tester.pump();
+    await tester.tap(find.text('Sipeed Official'));
+    await tester.pump();
+
+    expect(
+      launchedUris,
+      containsAll(<Uri>[
+        Uri.parse('https://picoclaw.io'),
+        Uri.parse('https://sipeed.com'),
+      ]),
+    );
+  });
+
+  testWidgets(
+    'shows feedback and keeps the dialog open when link launch fails',
+    (WidgetTester tester) async {
+      await pumpConfigPage(tester, launcher: (_) async => false);
+
+      await tester.tap(find.text('About'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('PicoClaw Official'));
+      await tester.pump();
+
+      expect(find.text("Couldn't open the official link."), findsOneWidget);
+      expect(find.text('Sipeed Official'), findsOneWidget);
+      expect(find.text('Close'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds an About entry to the Settings screen and introduces an About dialog for PicoClaw Flutter UI.

Users can now:
- Open an About dialog directly from Settings
- View basic project information
- Open the official PicoClaw website (`https://picoclaw.io`)
- Open the official Sipeed website (`https://sipeed.com`)

The dialog also preserves app stability when external link launching fails and shows user-facing feedback in that case.

## Changes

- Added an `About` action to the Settings header
- Added an About dialog with:
  - project title
  - short project description
  - PicoClaw official link
  - Sipeed official link
  - close action
- Added external link failure feedback
- Added localization strings for all supported locales
- Regenerated localization output files
- Added widget tests for:
  - opening and closing the dialog
  - rendering project information
  - rendering official links
  - handling link launch failures
- Added reviewer evidence notes in `docs/screenshots/about_dialog_review.md`

## Files of Interest

- `lib/src/ui/config_page.dart`
- `lib/l10n/*.arb`
- `lib/src/generated/l10n/*`
- `test/widgets/config_page_about_dialog_test.dart`
- `docs/screenshots/about_dialog_review.md`

## Testing

Ran:

- `flutter analyze lib/src/ui/config_page.dart test/widgets/config_page_about_dialog_test.dart`
- `flutter test test/widgets/config_page_about_dialog_test.dart`

## Notes

- The implementation reuses the existing Settings page structure and dialog patterns instead of introducing a new screen.
- External links continue to use the existing launcher approach.
- Link launch failures are surfaced with in-app feedback while keeping the dialog open.
