### PR TITLE
fix(ui): reduce focused button border width

### DIFF
--- a/lib/src/ui/config_page.dart
+++ b/lib/src/ui/config_page.dart
@@ -1040,7 +1040,7 @@ class _FocusableButtonState extends State<FocusableButton> {
                 style: widget.style?.copyWith(
                   side: WidgetStateProperty.all(
                     isFocused
-                        ? BorderSide(color: colorScheme.primary, width: 3)
+                        ? BorderSide(color: colorScheme.primary, width: 1)
                         : BorderSide.none,
                   ),
                 ),


### PR DESCRIPTION
# PR: Reduce Focus Button Outline Weight

## Title

`fix(ui): reduce focused button border width`

## Summary

- Reduces the focused `FocusableButton` border width from `3` to `1`.
- Keeps the existing focus behavior and color intact while making the outline less visually dominant.
- Improves the appearance of compact controls such as the Settings "About" button.

## Changes

- Updated `FocusableButton` focus-state border width in `lib/src/ui/config_page.dart`.

## Testing

- Visual verification in Flutter app:
  - Open Settings.
  - Move focus to the "About" button.
  - Confirm the focus outline is still visible but no longer appears overly thick.

## Risk

- All usages of `FocusableButton` now render a thinner focus border.
- If any TV-focused screen depends on the thicker outline for readability, it should be spot-checked.
