### PR TITLE
feat: add Volcengine TOS upload workflow for Android APK

### DIFF
--- a/.github/workflows/release_full.yml
+++ b/.github/workflows/release_full.yml
@@ -699,6 +699,8 @@ jobs:
   publish:
     needs: [build-android, build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.set-vars.outputs.release_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -716,14 +718,17 @@ jobs:
           find downloaded_artifacts -type f -exec mv -t . {} + || true
 
       - name: Set release vars from build outputs
+        id: set-vars
         run: |
           echo "RELEASE_BASE=${{ needs.build-android.outputs.release_base }}" >> $GITHUB_ENV
           echo "ARTIFACT_SUFFIX=${{ needs.build-android.outputs.artifact_suffix }}" >> $GITHUB_ENV
           if [[ "${{ inputs.use_fixed_tag }}" == "true" ]]; then
-            echo "RELEASE_TAG=${{ needs.build-android.outputs.release_base }}" >> $GITHUB_ENV
+            RELEASE_TAG="${{ needs.build-android.outputs.release_base }}"
           else
-            echo "RELEASE_TAG=${{ inputs.release_prefix || 'picoclaw_fui' }}-${{ needs.build-android.outputs.release_base }}" >> $GITHUB_ENV
+            RELEASE_TAG="${{ inputs.release_prefix || 'picoclaw_fui' }}-${{ needs.build-android.outputs.release_base }}"
           fi
+          echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
       - name: Publish Release and upload artifacts
         uses: ncipollo/release-action@v1
@@ -744,3 +749,10 @@ jobs:
             picoclaw_fui${{ env.ARTIFACT_SUFFIX }}-windows-x64-installer.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-tos:
+    needs: [publish]
+    uses: ./.github/workflows/upload-tos.yml
+    with:
+      tag: ${{ needs.publish.outputs.release_tag }}
+    secrets: inherit

--- a/.github/workflows/upload-tos.yml
+++ b/.github/workflows/upload-tos.yml
@@ -1,0 +1,46 @@
+name: Upload to Volcengine TOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to download and upload (e.g. picoclaw_fui-v0.2.0)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to download and upload"
+        required: true
+        type: string
+
+jobs:
+  upload-tos:
+    name: Upload to Volcengine TOS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ inputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --dir artifacts \
+            --pattern "*-android-universal.apk"
+
+      - name: Upload to Volcengine TOS
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.VOLC_TOS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.VOLC_TOS_SECRET_KEY }}
+          AWS_DEFAULT_REGION: cn-beijing
+        run: |
+          aws configure set default.s3.addressing_style virtual
+          TOS_ENDPOINT="https://tos-s3-cn-beijing.volces.com"
+          # Upload to versioned directory
+          aws s3 sync artifacts/ "s3://picoclaw-downloads/fui/${{ inputs.tag }}/" \
+            --endpoint-url "$TOS_ENDPOINT"
+          # Upload to latest (overwrite)
+          aws s3 sync artifacts/ "s3://picoclaw-downloads/fui/latest/" \
+            --endpoint-url "$TOS_ENDPOINT" \
+            --delete


### PR DESCRIPTION
Add upload-tos.yml that downloads the domestic Android APK from a GitHub Release and syncs it to Volcengine TOS (versioned + latest). Wire it into release_full.yml to run automatically after publish.