### PR TITLE
fix: skip TOS upload for nightly and testly builds

### DIFF
--- a/.github/workflows/release_full.yml
+++ b/.github/workflows/release_full.yml
@@ -756,6 +756,7 @@ jobs:
 
   upload-tos:
     needs: [publish]
+    if: ${{ !inputs.use_fixed_tag }}
     uses: ./.github/workflows/upload-tos.yml
     with:
       tag: ${{ needs.publish.outputs.release_tag }}


### PR DESCRIPTION
Nightly/testly builds were overwriting the official release APK on TOS. Gate the upload-tos job on `!inputs.use_fixed_tag` so only versioned releases upload to TOS.